### PR TITLE
Allow disabling of color

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a no-fuzz, barebone, zero muppetry color module for node.js.
 
+# Environment variables
+
+* The module respects the `NOCOLOR` environment variable if you wish to disable the coloring.
+
 # License
 
 MIT License

--- a/tinycolor.js
+++ b/tinycolor.js
@@ -1,3 +1,5 @@
+var tty = require('tty');
+
 var styles = {
   'bold':      ['\033[1m', '\033[22m'],
   'italic':    ['\033[3m', '\033[23m'],
@@ -24,7 +26,7 @@ var styles = {
   'bgDefault': ['\033[49m', '\033[49m']
 }
 
-var enabled = !process.env.NOCOLOR;
+var enabled = !process.env.NOCOLOR && tty.isatty(1) && tty.isatty(2);
 
 Object.keys(styles).forEach(function(style) {
   Object.defineProperty(String.prototype, style, {

--- a/tinycolor.js
+++ b/tinycolor.js
@@ -23,9 +23,12 @@ var styles = {
   'bgWhite':   ['\033[47m', '\033[49m'],
   'bgDefault': ['\033[49m', '\033[49m']
 }
+
+var enabled = !process.env.NOCOLOR;
+
 Object.keys(styles).forEach(function(style) {
   Object.defineProperty(String.prototype, style, {
-    get: function() { return styles[style][0] + this + styles[style][1]; },
+    get: function() { return (enabled ? styles[style][0] + this + styles[style][1] : this); },
     enumerable: false
   });
 });


### PR DESCRIPTION
Arguably, this could be handled by the dependent module, but in cases where it isn't, it would be nice to have control of the output.
